### PR TITLE
Fix UART message buffer overflow

### DIFF
--- a/Pancake_esp/main/InfluxDBCmdAndTlm.cpp
+++ b/Pancake_esp/main/InfluxDBCmdAndTlm.cpp
@@ -29,7 +29,7 @@ static int InfluxVprintf(const char *str, va_list args)
         size_t payloadLength = (len < sizeof(logBuffer)) ? len : sizeof(logBuffer) - 1;
 
         AddLogToBuffer(logBuffer);
-        SendProtocolMessage(MSG_TYPE_LOG, (uint8_t *)logBuffer, payloadLength);
+        (void)SendProtocolMessage(MSG_TYPE_LOG, (uint8_t *)logBuffer, payloadLength);
     }
     return len;
 }

--- a/Pancake_esp/main/PiUI.h
+++ b/Pancake_esp/main/PiUI.h
@@ -75,7 +75,7 @@ extern "C"
     void PiUIInit();
     void PiUIStart();
     void SerialCommunicationTask(void *pvParameters);
-    void SendProtocolMessage(uint8_t MessageType, const uint8_t *Payload, size_t PayloadLength);
+    esp_err_t SendProtocolMessage(uint8_t MessageType, const uint8_t *Payload, size_t PayloadLength);
     bool ParseTheMessage(const uint8_t *Data, size_t Length, parsed_message_t *Message);
     void RouteMessage(const parsed_message_t *Message);
     void telemetry_provider_handle_request();

--- a/tests/test_build_message.py
+++ b/tests/test_build_message.py
@@ -1,0 +1,18 @@
+import unittest
+from PiUI.PiUI import build_message, STX, ETX, ESC
+
+class TestBuildMessage(unittest.TestCase):
+    def test_large_payload_with_escapes(self):
+        # Payload containing many bytes that require escaping
+        payload = bytes([STX, ETX, ESC] * 85)  # 255 bytes total
+        msg = build_message(0x01, payload)
+        # Expected length: STX + type + len + escaped payload + checksum + ETX
+        expected_len = 5 + len(payload) * 2
+        self.assertEqual(len(msg), expected_len)
+        self.assertEqual(msg[0], STX)
+        self.assertEqual(msg[1], 0x01)
+        self.assertEqual(msg[2], len(payload))
+        self.assertEqual(msg[-1], ETX)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- prevent SendProtocolMessage from overflowing its buffer
- allocate worst-case length dynamically and return `esp_err_t`
- ignore returned value at call sites
- provide `__init__` file for PiUI package
- add regression test for encoding long escaped payloads

## Testing
- `pip install -r PiUI/requirements.txt`
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_688bc48bb2e08322b92a03737624aab1