### PR TITLE
Fix InfluxDB response parsing and add unit test

### DIFF
--- a/Pancake_esp/main/InfluxDBParser.cpp
+++ b/Pancake_esp/main/InfluxDBParser.cpp
@@ -1,0 +1,22 @@
+#include "InfluxDBParser.h"
+#include <sstream>
+#include <algorithm>
+#include <cctype>
+
+std::string get_last_non_empty_line(const std::string &body) {
+    std::istringstream stream(body);
+    std::string line;
+    std::string last;
+
+    while (std::getline(stream, line)) {
+        // Check if line has any non-whitespace character
+        auto it = std::find_if(line.begin(), line.end(), [](unsigned char ch) {
+            return !std::isspace(ch);
+        });
+        if (it != line.end()) {
+            last = line;
+        }
+    }
+
+    return last;
+}

--- a/Pancake_esp/main/InfluxDBParser.h
+++ b/Pancake_esp/main/InfluxDBParser.h
@@ -1,0 +1,11 @@
+#ifndef INFLUXDB_PARSER_H
+#define INFLUXDB_PARSER_H
+
+#include <string>
+
+// Return the last non-empty line from an InfluxDB CSV response.
+// Lines containing only whitespace are ignored. If no such line exists,
+// an empty string is returned.
+std::string get_last_non_empty_line(const std::string &body);
+
+#endif // INFLUXDB_PARSER_H

--- a/tests/test_influxdb_parser.cpp
+++ b/tests/test_influxdb_parser.cpp
@@ -1,0 +1,17 @@
+#include <cassert>
+#include <string>
+#include "../Pancake_esp/main/InfluxDBParser.h"
+
+int main() {
+    // Response with trailing blank line
+    std::string response = ",result,table,_start,_stop,_time,_value,_field,_measurement\n" 
+                           ",_result,0,2025-09-02T00:38:37.276148751Z,2025-09-02T00:43:37.276148751Z,2025-09-02T00:41:06.847Z,aQtIZWxsbyBXb3JsZA==,data,cmd\n\n";
+    std::string expected = ",_result,0,2025-09-02T00:38:37.276148751Z,2025-09-02T00:43:37.276148751Z,2025-09-02T00:41:06.847Z,aQtIZWxsbyBXb3JsZA==,data,cmd";
+    assert(get_last_non_empty_line(response) == expected);
+
+    // Response with all blank lines
+    std::string blank_response = "\n\n";
+    assert(get_last_non_empty_line(blank_response).empty());
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ignore trailing blank lines when parsing InfluxDB CSV responses
- factor line extraction into dedicated helper
- add unit test for helper to prevent regressions

## Testing
- `g++ tests/test_influxdb_parser.cpp Pancake_esp/main/InfluxDBParser.cpp -I Pancake_esp/main -o tests/test_influxdb_parser`
- `tests/test_influxdb_parser`
- `PYTHONPATH=. pytest tests/test_build_message.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b63e2f392c83229de83601c55c41f5