### PR TITLE
Fix InfluxDB CSV parsing and add tests

### DIFF
--- a/Pancake_esp/main/CMakeLists.txt
+++ b/Pancake_esp/main/CMakeLists.txt
@@ -10,4 +10,5 @@ idf_component_register(SRCS "StepperMotor.cpp"
  "PanMath.cpp"
  "WifiHandler.cpp"
  "InfluxDBCmdAndTlm.cpp"
+ "CommandHandler.cpp"
  INCLUDE_DIRS ".")

--- a/Pancake_esp/main/CommandHandler.cpp
+++ b/Pancake_esp/main/CommandHandler.cpp
@@ -32,7 +32,7 @@ static void handle_command(const uint8_t *data, size_t len) {
             size_t copy_len = payload_len < sizeof(msg) - 1 ? payload_len : sizeof(msg) - 1;
             memcpy(msg, data + 2, copy_len);
             msg[copy_len] = '\0';
-            ESP_LOGI("CommandParser", "%s", msg);
+            ESP_LOGD("CommandParser", "%s", msg);
             break;
         }
         default:

--- a/Pancake_esp/main/CommandHandler.cpp
+++ b/Pancake_esp/main/CommandHandler.cpp
@@ -1,0 +1,63 @@
+#include "CommandHandler.h"
+#include "esp_log.h"
+#include "mbedtls/base64.h"
+#include <cstring>
+#include <cassert>
+#include <cstdint>
+#include <freertos/task.h>
+
+static const char *TAG = "CommandHandler";
+
+QueueHandle_t cmd_queue;
+
+void CommandHandlerInit(void) {
+    cmd_queue = xQueueCreate(5, sizeof(cmd_payload_t));
+    assert(cmd_queue != NULL);
+}
+
+static void handle_command(const uint8_t *data, size_t len) {
+    if (len < 2) {
+        ESP_LOGE(TAG, "Command too short");
+        return;
+    }
+    uint8_t opcode = data[0];
+    uint8_t payload_len = data[1];
+    if (payload_len > len - 2) {
+        ESP_LOGE(TAG, "Invalid length byte");
+        return;
+    }
+    switch (opcode) {
+        case 0x69: {
+            char msg[CMD_PAYLOAD_MAX_LEN];
+            size_t copy_len = payload_len < sizeof(msg) - 1 ? payload_len : sizeof(msg) - 1;
+            memcpy(msg, data + 2, copy_len);
+            msg[copy_len] = '\0';
+            ESP_LOGI("CommandParser", "%s", msg);
+            break;
+        }
+        default:
+            ESP_LOGW(TAG, "Unknown opcode 0x%02X", opcode);
+            break;
+    }
+}
+
+void CommandHandlerTask(void *param) {
+    cmd_payload_t item;
+    for (;;) {
+        if (xQueueReceive(cmd_queue, &item, portMAX_DELAY) == pdTRUE) {
+            uint8_t decoded[CMD_PAYLOAD_MAX_LEN];
+            size_t out_len = 0;
+            if (mbedtls_base64_decode(decoded, sizeof(decoded), &out_len,
+                                      (const unsigned char *)item.payload,
+                                      strlen(item.payload)) != 0) {
+                ESP_LOGE(TAG, "Base64 decode failed");
+                continue;
+            }
+            handle_command(decoded, out_len);
+        }
+    }
+}
+
+void CommandHandlerStart(void) {
+    xTaskCreate(CommandHandlerTask, "CmdHandler", 4096, NULL, 1, NULL);
+}

--- a/Pancake_esp/main/CommandHandler.h
+++ b/Pancake_esp/main/CommandHandler.h
@@ -1,0 +1,21 @@
+#ifndef COMMAND_HANDLER_H
+#define COMMAND_HANDLER_H
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+#include <time.h>
+
+#define CMD_PAYLOAD_MAX_LEN 512
+
+typedef struct {
+    time_t timestamp;
+    char payload[CMD_PAYLOAD_MAX_LEN];
+} cmd_payload_t;
+
+extern QueueHandle_t cmd_queue;
+
+void CommandHandlerInit(void);
+void CommandHandlerStart(void);
+void CommandHandlerTask(void *param);
+
+#endif // COMMAND_HANDLER_H

--- a/Pancake_esp/main/InfluxDBCmdAndTlm.cpp
+++ b/Pancake_esp/main/InfluxDBCmdAndTlm.cpp
@@ -192,6 +192,9 @@ void CmdAndTlmInit(void)
 {
     TlmBufferMutex = xSemaphoreCreateMutex();
     assert(TlmBufferMutex != nullptr);
+
+    cmd_queue = xQueueCreate(5, sizeof(cmd_payload_t));
+    assert(cmd_queue != nullptr);
 }
 
 void CmdAndTlmStart(void)

--- a/Pancake_esp/main/InfluxDBParser.cpp
+++ b/Pancake_esp/main/InfluxDBParser.cpp
@@ -3,6 +3,34 @@
 #include <algorithm>
 #include <cctype>
 #include <vector>
+#include <cstdint>
+
+// Calculate days since Unix epoch for a given civil date.
+// Algorithm adapted from Howard Hinnant's date algorithms:
+// https://howardhinnant.github.io/date_algorithms.html
+static int days_from_civil(int y, unsigned m, unsigned d) {
+    y -= m <= 2;
+    const int era = (y >= 0 ? y : y - 399) / 400;
+    const unsigned yoe = static_cast<unsigned>(y - era * 400);      // [0, 399]
+    const unsigned doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1; // [0, 365]
+    const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;     // [0, 146096]
+    return era * 146097 + static_cast<int>(doe) - 719468;
+}
+
+static time_t utc_mktime(const struct tm &tm) {
+#if defined(_WIN32)
+    struct tm tmp = tm;
+    return _mkgmtime(&tmp);
+#elif defined(__GLIBC__)
+    struct tm tmp = tm;
+    return timegm(&tmp);
+#else
+    return static_cast<time_t>(days_from_civil(tm.tm_year + 1900,
+                                              static_cast<unsigned>(tm.tm_mon + 1),
+                                              static_cast<unsigned>(tm.tm_mday))) * 86400 +
+           tm.tm_hour * 3600 + tm.tm_min * 60 + tm.tm_sec;
+#endif
+}
 
 // Helper to parse ISO8601 timestamps of the form
 // "YYYY-MM-DDTHH:MM:SS.mmmZ" or without fractional seconds.
@@ -19,11 +47,7 @@ static bool parse_iso8601(const std::string &token, time_t &out) {
     if (!strptime(ts.c_str(), "%Y-%m-%dT%H:%M:%S", &tm)) {
         return false;
     }
-#if defined(_BSD_SOURCE) || defined(_GNU_SOURCE) || defined(__APPLE__)
-    out = timegm(&tm);
-#else
-    out = mktime(&tm); // Fall back to local time if timegm is unavailable
-#endif
+    out = utc_mktime(tm);
     return true;
 }
 

--- a/Pancake_esp/main/InfluxDBParser.cpp
+++ b/Pancake_esp/main/InfluxDBParser.cpp
@@ -2,6 +2,30 @@
 #include <sstream>
 #include <algorithm>
 #include <cctype>
+#include <vector>
+
+// Helper to parse ISO8601 timestamps of the form
+// "YYYY-MM-DDTHH:MM:SS.mmmZ" or without fractional seconds.
+static bool parse_iso8601(const std::string &token, time_t &out) {
+    std::string ts = token;
+    if (!ts.empty() && ts.back() == 'Z') {
+        ts.pop_back();
+    }
+    size_t dot = ts.find('.');
+    if (dot != std::string::npos) {
+        ts = ts.substr(0, dot);
+    }
+    struct tm tm = {};
+    if (!strptime(ts.c_str(), "%Y-%m-%dT%H:%M:%S", &tm)) {
+        return false;
+    }
+#if defined(_BSD_SOURCE) || defined(_GNU_SOURCE) || defined(__APPLE__)
+    out = timegm(&tm);
+#else
+    out = mktime(&tm); // Fall back to local time if timegm is unavailable
+#endif
+    return true;
+}
 
 std::string get_last_non_empty_line(const std::string &body) {
     std::istringstream stream(body);
@@ -19,4 +43,36 @@ std::string get_last_non_empty_line(const std::string &body) {
     }
 
     return last;
+}
+
+bool parse_influxdb_command(const std::string &body, InfluxDBCommand &cmd) {
+    // Look for data marker in response to ensure there is a result row
+    if (body.find(",_result,0,") == std::string::npos) {
+        return false;
+    }
+
+    std::string last_line = get_last_non_empty_line(body);
+    if (last_line.empty()) {
+        return false;
+    }
+
+    std::vector<std::string> tokens;
+    std::stringstream ss(last_line);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        tokens.push_back(item);
+    }
+
+    if (tokens.size() < 7) {
+        return false;
+    }
+
+    time_t timestamp;
+    if (!parse_iso8601(tokens[5], timestamp)) {
+        return false;
+    }
+
+    cmd.timestamp = timestamp;
+    cmd.payload = tokens[6];
+    return true;
 }

--- a/Pancake_esp/main/InfluxDBParser.h
+++ b/Pancake_esp/main/InfluxDBParser.h
@@ -2,10 +2,24 @@
 #define INFLUXDB_PARSER_H
 
 #include <string>
+#include <ctime>
+
+// Simple structure to hold a command extracted from InfluxDB.
+// The payload string remains base64 encoded as received from the CSV
+// response so that the caller can decide how and when to decode it.
+struct InfluxDBCommand {
+    time_t timestamp;      // UTC timestamp of the command
+    std::string payload;   // Base64 encoded payload
+};
 
 // Return the last non-empty line from an InfluxDB CSV response.
 // Lines containing only whitespace are ignored. If no such line exists,
 // an empty string is returned.
 std::string get_last_non_empty_line(const std::string &body);
+
+// Parse an InfluxDB annotated CSV response and extract the timestamp and
+// payload from the last non-empty data line. Returns true on success and
+// populates the provided InfluxDBCommand structure.
+bool parse_influxdb_command(const std::string &body, InfluxDBCommand &cmd);
 
 #endif // INFLUXDB_PARSER_H

--- a/tests/test_influxdb_parser.cpp
+++ b/tests/test_influxdb_parser.cpp
@@ -1,16 +1,34 @@
 #include <cassert>
 #include <string>
+#include <ctime>
 #include "../Pancake_esp/main/InfluxDBParser.h"
 
 int main() {
     // Response with trailing blank line
-    std::string response = ",result,table,_start,_stop,_time,_value,_field,_measurement\n" 
+    std::string response = ",result,table,_start,_stop,_time,_value,_field,_measurement\n"
                            ",_result,0,2025-09-02T00:38:37.276148751Z,2025-09-02T00:43:37.276148751Z,2025-09-02T00:41:06.847Z,aQtIZWxsbyBXb3JsZA==,data,cmd\n\n";
     std::string expected = ",_result,0,2025-09-02T00:38:37.276148751Z,2025-09-02T00:43:37.276148751Z,2025-09-02T00:41:06.847Z,aQtIZWxsbyBXb3JsZA==,data,cmd";
     assert(get_last_non_empty_line(response) == expected);
 
+    InfluxDBCommand cmd;
+    assert(parse_influxdb_command(response, cmd));
+
+    // Expected timestamp: 2025-09-02T00:41:06Z (milliseconds are ignored)
+    struct tm tm = {};
+    tm.tm_year = 2025 - 1900;
+    tm.tm_mon = 9 - 1;
+    tm.tm_mday = 2;
+    tm.tm_hour = 0;
+    tm.tm_min = 41;
+    tm.tm_sec = 6;
+    time_t expected_ts = timegm(&tm);
+    assert(cmd.timestamp == expected_ts);
+    assert(cmd.payload == "aQtIZWxsbyBXb3JsZA==");
+
     // Response with all blank lines
     std::string blank_response = "\n\n";
+    InfluxDBCommand cmd_blank;
+    assert(!parse_influxdb_command(blank_response, cmd_blank));
     assert(get_last_non_empty_line(blank_response).empty());
 
     return 0;


### PR DESCRIPTION
## Summary
- Handle ISO8601 timestamps with fractional seconds and trailing Z
- Move all CSV parsing to InfluxDBParser and expose structured command
- Extend parser unit test to verify timestamp and payload values

## Testing
- `g++ -std=c++17 tests/test_influxdb_parser.cpp Pancake_esp/main/InfluxDBParser.cpp -o test_influxdb_parser && ./test_influxdb_parser`
- `PYTHONPATH=. python tests/test_build_message.py`


------
https://chatgpt.com/codex/tasks/task_e_68b645c30ed88322bd938a78c12cdfef