### PR TITLE
Preserve serial log output while mirroring logs to telemetry

### DIFF
--- a/Pancake_esp/main/InfluxDBCmdAndTlm.cpp
+++ b/Pancake_esp/main/InfluxDBCmdAndTlm.cpp
@@ -9,6 +9,7 @@
 #include "freertos/portmacro.h"
 
 static const char *TAG = "InfluxDBCmdAndTlm";
+static vprintf_like_t PreviousLogVprintf = nullptr;
 
 SemaphoreHandle_t TlmBufferMutex = nullptr;
 
@@ -170,12 +171,27 @@ esp_err_t _http_event_handler(esp_http_client_event_t *evt) {
 
 static int InfluxVprintf(const char *str, va_list args)
 {
+    va_list args_for_serial;
+    va_copy(args_for_serial, args);
+
     char logBuffer[LOG_MSG_MAX_LEN];
     int len = vsnprintf(logBuffer, sizeof(logBuffer), str, args);
     if (len > 0) {
         size_t payloadLength = (len < sizeof(logBuffer)) ? (size_t)len : sizeof(logBuffer) - 1;
         // Push to lightweight ring; do not call ESP_LOG* or FreeRTOS APIs here
         log_ring_push(logBuffer, payloadLength);
+    }
+
+    // Preserve default ESP-IDF logging sink (UART/JTAG) so logs remain visible
+    // on the same serial connection used for flashing/monitoring.
+    int serial_len = 0;
+    if (PreviousLogVprintf != nullptr) {
+        serial_len = PreviousLogVprintf(str, args_for_serial);
+    }
+    va_end(args_for_serial);
+
+    if (serial_len > len) {
+        return serial_len;
     }
     return len;
 }
@@ -237,8 +253,8 @@ void CmdAndTlmStart(void)
     xTaskCreate(AggregateTlmTask, "TlmAggregate", 8192, NULL, 1, &AggregateTlmTaskHandle);
     xTaskCreate(QueryCmdTask, "CmdQuery", 8192, NULL, 1, &QueryCmdsTaskHandle);
 
-    // Enable log capture to ring buffer
-    esp_log_set_vprintf(InfluxVprintf);
+    // Enable log capture to ring buffer and keep the prior UART/JTAG sink active.
+    PreviousLogVprintf = esp_log_set_vprintf(InfluxVprintf);
     CommandHandlerStart();
 }
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ Firmware is built with ESP-IDF and lives under `Pancake_esp/`. Key modules:
 
 To build the firmware you will need the ESP-IDF toolchain (v5.x recommended). After configuring credentials in `sdkconfig`/`Secret.h`, standard `idf.py build flash monitor` targets apply.
 
+### Viewing ESP logs over the flash serial port (macOS)
+The firmware keeps ESP-IDF logging active on the default serial sink, so anything emitted with `ESP_LOG*` can be viewed on the same USB serial device used for flashing.
+
+1. List serial devices:
+   ```bash
+   ls /dev/cu.usb*
+   ```
+2. Open a monitor (replace the port with your device):
+   ```bash
+   idf.py -p /dev/cu.usbmodemXXXX monitor
+   ```
+   If you are outside an ESP-IDF shell, a simple fallback is:
+   ```bash
+   screen /dev/cu.usbmodemXXXX 115200
+   ```
+3. Exit monitor:
+   - `idf.py monitor`: press `Ctrl+]`
+   - `screen`: press `Ctrl+A`, then `K`, then `Y`
+
 ## Ground Station Tools
 `GroundStation/CommandTerminal.py` is a CLI utility for sending commands through InfluxDB using a human-readable syntax. Example interactions:
 


### PR DESCRIPTION
### Motivation
- The telemetry hook `InfluxVprintf` was installed with `esp_log_set_vprintf(...)` and replaced the default ESP-IDF log sink, which caused `ESP_LOG*` output to disappear from the serial (flashing/monitor) console.
- Keep existing telemetry capture (ring buffer → Influx) while restoring visibility on the same UART/JTAG serial used for flashing and `idf.py monitor`.

### Description
- Store the previous vprintf sink in `PreviousLogVprintf` and install the telemetry hook with `PreviousLogVprintf = esp_log_set_vprintf(InfluxVprintf);` in `CmdAndTlmStart()` (file `Pancake_esp/main/InfluxDBCmdAndTlm.cpp`).
- In `InfluxVprintf` copy the `va_list` with `va_copy`, push the formatted line into the telemetry `LogRing`, then forward the same format+args to the saved `PreviousLogVprintf` so logs still appear on serial.
- Ensure `va_end` is called after forwarding and return the larger of the ring-buffer or serial write lengths to preserve normal `vprintf` semantics.
- Add a short macOS how-to in `README.md` showing `ls /dev/cu.usb*`, `idf.py -p /dev/cu.usbmodemXXXX monitor`, and a `screen` fallback for viewing serial output.

### Testing
- Ran code inspection and diffs to verify the changes to `Pancake_esp/main/InfluxDBCmdAndTlm.cpp` and `README.md` and confirmed the new `PreviousLogVprintf` usage and `va_copy` forwarding were present; these checks succeeded.
- Verified repository status to confirm only the intended files were modified; this check succeeded.
- Attempted to run `idf.py --version` in the environment to exercise the local monitor workflow, but `idf.py` is not installed here so a firmware build/serial runtime test could not be performed (environmental limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eea1a61c908322b6ba0466ec77589f)