### PR TITLE
Add local_origin support and multi-pattern run_files

### DIFF
--- a/GroundStation/CommandTerminal.py
+++ b/GroundStation/CommandTerminal.py
@@ -548,14 +548,16 @@ def _write_packet(packet: bytes) -> None:
 
 def _run_file(path: str, delay_ms: int, run_file_stack: Optional[List[str]] = None) -> None:
     stack = run_file_stack if run_file_stack is not None else []
-    abs_path = os.path.abspath(path)
+    base_dir = os.path.dirname(stack[-1]) if stack and not os.path.isabs(path) else ""
+    resolved_path = os.path.join(base_dir, path) if base_dir else path
+    abs_path = os.path.abspath(resolved_path)
     if abs_path in stack:
         chain = " -> ".join([*stack, abs_path])
         raise ValueError(f"Recursive run_file call disallowed: {chain}")
 
     stack.append(abs_path)
     try:
-        with open(path, 'r', encoding='utf-8') as f:
+        with open(abs_path, 'r', encoding='utf-8') as f:
             for raw in f:
                 s = raw.strip()
                 if not s or s.startswith('#'):

--- a/GroundStation/CommandTerminal.py
+++ b/GroundStation/CommandTerminal.py
@@ -11,6 +11,7 @@ Simplified syntax (no leading / or -a):
   cnc_go_to_angle TargetS0_deg=0 TargetS1_deg=0 AngleTolerance_deg=0.25
   cnc_home
   cnc_go_home
+  local_origin OriginX_m=0.0 OriginY_m=0.0
 
 Run a newline-delimited program file:
   run_file TestProgram.txt
@@ -71,6 +72,7 @@ CNC_OPCODES: Dict[str, int] = {
     "cnc_go_to_angle": 0x1C,
     "cnc_home": 0x1D,
     "cnc_go_home": 0x1E,
+    "local_origin": 0x1F,
 }
 
 # Immediate control opcodes
@@ -124,6 +126,7 @@ def print_help() -> None:
     print("  cnc_go_to_angle TargetS0_deg=<deg> TargetS1_deg=<deg> AngleTolerance_deg=<deg>")
     print("  cnc_home")
     print("  cnc_go_home")
+    print("  local_origin OriginX_m=<m> OriginY_m=<m>")
     print("  pump_purge pumpSpeed_degps=<signed deg/s> duration_ms=<ms>")
     print("  wait timeout_ms=<int>")
     print("  set_motor_limits motor=<S0|S1|Pump|All> accel=<degps2> speed=<degps>")
@@ -188,6 +191,11 @@ COMMAND_HELP: Dict[str, str] = {
     ),
     "cnc_home": "cnc_home — calibrate S0/S1 from the limit switches, then return to 0/0.",
     "cnc_go_home": "cnc_go_home — move stages to S0=90, S1=180.",
+    "local_origin": (
+        "local_origin keys:\n"
+        "  OriginX_m: float local X offset added to later cartesian commands\n"
+        "  OriginY_m: float local Y offset added to later cartesian commands"
+    ),
     "wait": (
         "wait keys:\n"
         "  timeout_ms: int"
@@ -248,6 +256,8 @@ CMD_ALIASES: Dict[str, str] = {
     "SetPumpConstant": "set_pump_constant",
     "SetAccelScale": "set_accel_scale",
     "PumpPurge": "pump_purge",
+    "LocalOrigin": "local_origin",
+    "SetLocalOrigin": "local_origin",
 }
 
 def _canonical_cmd_name(cmd: str) -> str:
@@ -414,6 +424,13 @@ def _build_cnc_payload(cmd: str, args: Dict[str, Any]) -> Tuple[int, bytes]:
         if args:
             raise ValueError(f"{cmd} does not take arguments")
         return op, b""
+    elif cmd == "local_origin":
+        allowed = {"OriginX_m", "OriginY_m"}
+        unknown = set(args.keys()) - allowed
+        if unknown:
+            raise ValueError(f"Unknown keys for local_origin: {', '.join(sorted(unknown))}")
+        payload = struct.pack("<ff", float(args.get("OriginX_m", 0.0)), float(args.get("OriginY_m", 0.0)))
+        return op, payload
     elif cmd == "pump_purge":
         return op, _build_pump_purge_payload(args)
     else:
@@ -529,22 +546,15 @@ def _write_packet(packet: bytes) -> None:
     resp.raise_for_status()
 
 
-def _send_command(line: str) -> bool:
-    parts = shlex.split(line)
-    if not parts:
-        return False
-    if parts[0] == "run_file":
-        if len(parts) < 2:
-            raise ValueError("usage: run_file <path> [delay_ms]")
-        path = parts[1]
-        delay_ms = 0
-        if len(parts) >= 3:
-            try:
-                delay_ms = int(parts[2])
-            except ValueError:
-                raise ValueError("delay_ms must be integer milliseconds")
-        if delay_ms <= 0:
-            delay_ms = int(os.environ.get('CT_RUNFILE_DELAY_MS', '800'))
+def _run_file(path: str, delay_ms: int, run_file_stack: Optional[List[str]] = None) -> None:
+    stack = run_file_stack if run_file_stack is not None else []
+    abs_path = os.path.abspath(path)
+    if abs_path in stack:
+        chain = " -> ".join([*stack, abs_path])
+        raise ValueError(f"Recursive run_file call disallowed: {chain}")
+
+    stack.append(abs_path)
+    try:
         with open(path, 'r', encoding='utf-8') as f:
             for raw in f:
                 s = raw.strip()
@@ -564,7 +574,7 @@ def _send_command(line: str) -> bool:
                             break
                         if resp in {'n', 'no'}:
                             print("Aborted by user.")
-                            return True
+                            return
                         print("Please respond with 'y' or 'n'.")
                     continue
                 if cmd2 == 'terminal_wait':
@@ -575,6 +585,10 @@ def _send_command(line: str) -> bool:
                     print(f"{DIM}↳ {s}{RESET}")
                     time.sleep(max(0, dur) / 1000.0)
                     continue
+                if cmd2 == 'run_file':
+                    print(f"{DIM}↳ {s}{RESET}")
+                    _send_command(s, stack)
+                    continue
 
                 pkt = _build_command_packet(s)
 
@@ -583,7 +597,27 @@ def _send_command(line: str) -> bool:
                     print(f"{DIM}↳ {s}{RESET}")
                     _write_packet(pkt)
                     time.sleep(delay_ms / 1000.0)
-                
+    finally:
+        stack.pop()
+
+
+def _send_command(line: str, run_file_stack: Optional[List[str]] = None) -> bool:
+    parts = shlex.split(line)
+    if not parts:
+        return False
+    if parts[0] == "run_file":
+        if len(parts) < 2:
+            raise ValueError("usage: run_file <path> [delay_ms]")
+        path = parts[1]
+        delay_ms = 0
+        if len(parts) >= 3:
+            try:
+                delay_ms = int(parts[2])
+            except ValueError:
+                raise ValueError("delay_ms must be integer milliseconds")
+        if delay_ms <= 0:
+            delay_ms = int(os.environ.get('CT_RUNFILE_DELAY_MS', '800'))
+        _run_file(path, delay_ms, run_file_stack)
         return True
 
     # Command-specific help
@@ -646,6 +680,7 @@ def main() -> None:
             "cnc_go_to_angle",
             "cnc_home",
             "cnc_go_home",
+            "local_origin",
             "pump_purge",
             "ask_to_continue",
             "terminal_wait",
@@ -680,6 +715,7 @@ def main() -> None:
             "cnc_go_to_angle": ["TargetS0_deg", "TargetS1_deg", "AngleTolerance_deg"],
             "cnc_home": [],
             "cnc_go_home": [],
+            "local_origin": ["OriginX_m", "OriginY_m"],
             "pump_purge": ["pumpSpeed_degps", "duration_ms"],
             "terminal_wait": ["duration_ms"],
         }

--- a/GroundStation/GCode/multi_smile.txt
+++ b/GroundStation/GCode/multi_smile.txt
@@ -1,0 +1,16 @@
+# Print multiple smiley pancakes from one run_file.
+# Each included pattern uses cartesian coordinates relative to local_origin.
+
+local_origin OriginX_m=0.06 OriginY_m=0.14
+run_file GroundStation/GCode/smily_pattern.txt
+
+local_origin OriginX_m=0.18 OriginY_m=0.14
+run_file GroundStation/GCode/smily_pattern.txt
+
+local_origin OriginX_m=0.06 OriginY_m=0.27
+run_file GroundStation/GCode/smily_pattern.txt
+
+local_origin OriginX_m=0.18 OriginY_m=0.27
+run_file GroundStation/GCode/smily_pattern.txt
+
+local_origin OriginX_m=0.0 OriginY_m=0.0

--- a/GroundStation/GCode/multi_work_logo.txt
+++ b/GroundStation/GCode/multi_work_logo.txt
@@ -1,0 +1,16 @@
+# Print multiple work-logo pancakes from one run_file.
+# Each included pattern uses cartesian coordinates relative to local_origin.
+
+local_origin OriginX_m=0.06 OriginY_m=0.14
+run_file GroundStation/GCode/work_logo_pattern.txt
+
+local_origin OriginX_m=0.18 OriginY_m=0.14
+run_file GroundStation/GCode/work_logo_pattern.txt
+
+local_origin OriginX_m=0.06 OriginY_m=0.27
+run_file GroundStation/GCode/work_logo_pattern.txt
+
+local_origin OriginX_m=0.18 OriginY_m=0.27
+run_file GroundStation/GCode/work_logo_pattern.txt
+
+local_origin OriginX_m=0.0 OriginY_m=0.0

--- a/GroundStation/GCode/smily_pattern.txt
+++ b/GroundStation/GCode/smily_pattern.txt
@@ -1,0 +1,36 @@
+# Smiley pattern centered at local origin 
+
+# Start by asserting CNC settings
+SetMotorLimits motor=S0 accel=20.0 speed=500.0
+SetMotorLimits motor=S1 accel=20.0 speed=500.0
+SetMotorLimits motor=Pump accel=20.0 speed=800.0
+set_pump_constant pumpConstant_degpm=200.0
+set_accel_scale accelScale=1.0
+
+# Draw pancake perimeter
+cnc_jog LinearSpeed_mps=0.03 TargetX_m=0 TargetY_m=0.05 PumpOn=0
+cnc_arc StartTheta_rad=0 EndTheta_rad=6.28 Radius_m=0.05 CenterX_m=0 CenterY_m=0 LinearSpeed_mps=0.1
+wait timeout_ms=2000
+
+# Jog to the mouth Start
+cnc_jog LinearSpeed_mps=0.03 TargetX_m=0.025 TargetY_m=0 PumpOn=0
+
+
+# mouth
+cnc_arc StartTheta_rad=1.9 EndTheta_rad=4.6 Radius_m=0.025 CenterX_m=0 CenterY_m=0 LinearSpeed_mps=0.1
+wait timeout_ms=2000
+
+# Jog to eye
+cnc_jog LinearSpeed_mps=0.03 TargetX_m=-0.015 TargetY_m=0.035 PumpOn=0
+cnc_arc StartTheta_rad=0 EndTheta_rad=6.28 Radius_m=0.01 CenterX_m=-0.015 CenterY_m=0.045 LinearSpeed_mps=0.05
+wait timeout_ms=2000
+
+cnc_jog LinearSpeed_mps=0.03 TargetX_m=0.015 TargetY_m=0.035 PumpOn=0
+cnc_arc StartTheta_rad=0 EndTheta_rad=6.28 Radius_m=0.01 CenterX_m=0.015 CenterY_m=0.045 LinearSpeed_mps=0.05
+
+cnc_go_home
+wait timeout_ms=2000
+
+# Fill in the pancake
+cnc_spiral CenterY_m=0 CenterX_m=0 MaxRadius_m=0.05 SpiralConstant_mprad=0.001 SpiralRate_radps=10.0 LinearSpeed_mps=0.5
+cnc_go_home

--- a/GroundStation/GCode/work_logo_pattern.txt
+++ b/GroundStation/GCode/work_logo_pattern.txt
@@ -1,0 +1,34 @@
+# Lux Aeterna space logo centered at local origin
+# Multi-pass approximation using arcs for the ring strokes and orbit stroke.
+
+# Start by asserting CNC settings
+SetMotorLimits motor=S0 accel=20.0 speed=500.0
+SetMotorLimits motor=S1 accel=20.0 speed=500.0
+SetMotorLimits motor=Pump accel=20.0 speed=800.0
+set_pump_constant pumpConstant_degpm=200.0
+set_accel_scale accelScale=1.0
+
+# Central orbit arc. Its endpoints are shared with the two outer arcs.
+cnc_jog TargetX_m=-0.053211 TargetY_m=-0.023077 LinearSpeed_mps=0.030000 PumpOn=0
+cnc_arc StartTheta_rad=-0.681804 EndTheta_rad=0.021804 Radius_m=0.167788 CenterX_m=0.052527 CenterY_m=-0.153354 LinearSpeed_mps=0.045000
+
+# Upper-left outer arc, top connector, and inner arc.
+cnc_jog TargetX_m=-0.053211 TargetY_m=-0.023077 LinearSpeed_mps=0.030000 PumpOn=0
+cnc_arc StartTheta_rad=-1.980000 EndTheta_rad=0.000000 Radius_m=0.058000 CenterX_m=0 CenterY_m=0 LinearSpeed_mps=0.045000
+
+cnc_jog TargetX_m=0 TargetY_m=0.04 LinearSpeed_mps=0.045000 PumpOn=1
+
+cnc_jog TargetX_m=0.0287 TargetY_m=0.028 LinearSpeed_mps=0.03000 PumpOn=0
+
+
+cnc_arc StartTheta_rad=0.8000 EndTheta_rad=-1.500000 Radius_m=0.040000 CenterX_m=0 CenterY_m=0 LinearSpeed_mps=0.045000
+
+# Lower-right outer arc, bottom connector, and inner arc.
+cnc_jog TargetX_m=0.056185 TargetY_m=0.014394 LinearSpeed_mps=0.030000 PumpOn=0
+cnc_arc StartTheta_rad=1.320000 EndTheta_rad=3.141593 Radius_m=0.058000 CenterX_m=0 CenterY_m=0 LinearSpeed_mps=0.045000
+cnc_jog TargetX_m=0 TargetY_m=-0.04 LinearSpeed_mps=0.045000 PumpOn=1
+cnc_jog TargetX_m=-0.031541 TargetY_m=-0.0246 LinearSpeed_mps=0.030000 PumpOn=0
+cnc_arc StartTheta_rad=4.050000 EndTheta_rad=1.800000 Radius_m=0.040000 CenterX_m=0 CenterY_m=0 LinearSpeed_mps=0.045000
+
+wait timeout_ms=500
+cnc_go_home

--- a/GroundStation/VisualizeRunFile.py
+++ b/GroundStation/VisualizeRunFile.py
@@ -57,6 +57,7 @@ LOCAL_COMMANDS = {
     "resume",
     "stop",
     "crash_diagnostic",
+    "local_origin",
 }
 
 
@@ -205,30 +206,81 @@ def get_reachable_rectangle_corners(inset_m: float = 0.0) -> list[Vec2]:
     ]
 
 
-def parse_program(path: Path) -> list[ParsedCommand]:
+def _apply_local_origin(cmd: str, args: dict[str, Any], local_origin: Vec2) -> dict[str, Any]:
+    """Return args with firmware-style local origin applied to cartesian fields."""
+    adjusted = dict(args)
+    if cmd == "cnc_jog":
+        adjusted["TargetX_m"] = float(adjusted["TargetX_m"]) + local_origin.x
+        adjusted["TargetY_m"] = float(adjusted["TargetY_m"]) + local_origin.y
+    elif cmd in {"cnc_arc", "cnc_spiral"}:
+        adjusted["CenterX_m"] = float(adjusted["CenterX_m"]) + local_origin.x
+        adjusted["CenterY_m"] = float(adjusted["CenterY_m"]) + local_origin.y
+    return adjusted
+
+
+def _resolve_run_file_path(path_text: str, including_path: Path) -> Path:
+    path = Path(path_text)
+    if path.is_absolute():
+        return path
+    candidate = including_path.parent / path
+    if candidate.exists():
+        return candidate
+    return path
+
+
+def _parse_program(path: Path, include_stack: list[Path], local_origin: Vec2) -> tuple[list[ParsedCommand], Vec2]:
+    resolved_path = path.resolve()
+    if resolved_path in include_stack:
+        chain = " -> ".join(str(item) for item in [*include_stack, resolved_path])
+        raise IntentError(f"recursive run_file include disallowed: {chain}")
+
     commands: list[ParsedCommand] = []
-    for line_no, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
+    include_stack.append(resolved_path)
+    lines = resolved_path.read_text(encoding="utf-8").splitlines()
+    try:
+        for line_no, raw_line in enumerate(lines, start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
 
-        parts = shlex.split(line)
-        if not parts:
-            continue
+            parts = shlex.split(line)
+            if not parts:
+                continue
 
-        cmd = _canonical_cmd_name(parts[0])
-        if len(parts) >= 2 and parts[1].lower() in {"help", "-h", "?"}:
-            continue
+            cmd = _canonical_cmd_name(parts[0])
+            if len(parts) >= 2 and parts[1].lower() in {"help", "-h", "?"}:
+                continue
 
-        if cmd in {"ask_to_continue", "e"}:
-            args: dict[str, Any] = {}
-        else:
-            args = _parse_kv_tokens(parts[1:])
+            if cmd == "run_file":
+                if len(parts) < 2:
+                    raise IntentError(f"line {line_no}: run_file requires a path")
+                child_path = _resolve_run_file_path(parts[1], resolved_path)
+                child_commands, local_origin = _parse_program(child_path, include_stack, local_origin)
+                commands.extend(child_commands)
+                continue
 
-        if cmd in DEFAULTS:
-            args = {**DEFAULTS[cmd], **args}
+            if cmd in {"ask_to_continue", "e"}:
+                args: dict[str, Any] = {}
+            else:
+                args = _parse_kv_tokens(parts[1:])
 
-        commands.append(ParsedCommand(line_no=line_no, raw=line, cmd=cmd, args=args))
+            if cmd in DEFAULTS:
+                args = {**DEFAULTS[cmd], **args}
+
+            if cmd == "local_origin":
+                local_origin = Vec2(float(args.get("OriginX_m", 0.0)), float(args.get("OriginY_m", 0.0)))
+            else:
+                args = _apply_local_origin(cmd, args, local_origin)
+
+            commands.append(ParsedCommand(line_no=line_no, raw=line, cmd=cmd, args=args))
+    finally:
+        include_stack.pop()
+
+    return commands, local_origin
+
+
+def parse_program(path: Path) -> list[ParsedCommand]:
+    commands, _ = _parse_program(path, [], Vec2(0.0, 0.0))
     return commands
 
 

--- a/GroundStation/tests/test_command_terminal.py
+++ b/GroundStation/tests/test_command_terminal.py
@@ -1,14 +1,17 @@
+import os
 import struct
 import sys
+import tempfile
 import types
 import unittest
+from unittest import mock
 
 # CommandTerminal only needs requests when writing packets, but requests is not
 # installed in all test environments. Provide a lightweight import stub so
 # serialization tests can import the module without exercising network writes.
 sys.modules.setdefault("requests", types.SimpleNamespace())
 
-from GroundStation.CommandTerminal import _build_command_packet, _build_pump_purge_payload
+from GroundStation.CommandTerminal import _build_command_packet, _build_pump_purge_payload, _send_command
 
 
 class CommandTerminalPacketTests(unittest.TestCase):
@@ -31,6 +34,42 @@ class CommandTerminalPacketTests(unittest.TestCase):
         self.assertEqual(payload_len, struct.calcsize("<fi"))
         self.assertEqual(speed, -300.0)
         self.assertEqual(duration, 500)
+
+    def test_local_origin_packet(self):
+        packet = _build_command_packet("local_origin OriginX_m=0.12 OriginY_m=0.34")
+
+        self.assertIsNotNone(packet)
+        opcode, payload_len = packet[:2]
+        origin_x, origin_y = struct.unpack("<ff", packet[2:])
+
+        self.assertEqual(opcode, 0x1F)
+        self.assertEqual(payload_len, struct.calcsize("<ff"))
+        self.assertAlmostEqual(origin_x, 0.12)
+        self.assertAlmostEqual(origin_y, 0.34)
+
+    def test_run_file_can_call_run_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            child = os.path.join(tmp, "child.txt")
+            parent = os.path.join(tmp, "parent.txt")
+            with open(child, "w", encoding="utf-8") as f:
+                f.write("local_origin OriginX_m=0.1 OriginY_m=0.2\n")
+            with open(parent, "w", encoding="utf-8") as f:
+                f.write(f"run_file {child} 1\n")
+
+            with mock.patch("GroundStation.CommandTerminal._write_packet") as write_packet:
+                self.assertTrue(_send_command(f"run_file {parent} 1"))
+
+        write_packet.assert_called_once()
+        self.assertEqual(write_packet.call_args.args[0][0], 0x1F)
+
+    def test_run_file_disallows_recursion(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            recursive = os.path.join(tmp, "recursive.txt")
+            with open(recursive, "w", encoding="utf-8") as f:
+                f.write(f"run_file {recursive} 1\n")
+
+            with self.assertRaisesRegex(ValueError, "Recursive run_file call disallowed"):
+                _send_command(f"run_file {recursive} 1")
 
 
 if __name__ == "__main__":

--- a/GroundStation/tests/test_visualize_run_file.py
+++ b/GroundStation/tests/test_visualize_run_file.py
@@ -8,6 +8,7 @@ from GroundStation.VisualizeRunFile import (
     DRAW_LINE_WIDTH,
     GO_HOME_S0_DEG,
     GO_HOME_S1_DEG,
+    IntentError,
     ParsedCommand,
     TRAVEL_LINE_WIDTH,
     Vec2,
@@ -18,6 +19,7 @@ from GroundStation.VisualizeRunFile import (
     plot_simulation,
     save_animation_gif,
     simulate_commands,
+    simulate_file,
 )
 
 
@@ -63,6 +65,44 @@ class VisualizeRunFileTests(unittest.TestCase):
         self.assertGreaterEqual(len(commands), 8)
         self.assertIn("cnc_spiral", [command.cmd for command in commands])
         self.assertEqual(motion_commands[0], "cnc_jog")
+
+    def test_parse_program_expands_nested_run_file_and_local_origin(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            child = root / "child.txt"
+            parent = root / "parent.txt"
+            child.write_text(
+                "cnc_jog TargetX_m=0.01 TargetY_m=0.02 LinearSpeed_mps=0.03 PumpOn=0\n",
+                encoding="utf-8",
+            )
+            parent.write_text(
+                "local_origin OriginX_m=0.10 OriginY_m=0.20\n"
+                "run_file child.txt\n",
+                encoding="utf-8",
+            )
+
+            commands = parse_program(parent)
+
+        self.assertEqual([command.cmd for command in commands], ["local_origin", "cnc_jog"])
+        self.assertAlmostEqual(commands[1].args["TargetX_m"], 0.11)
+        self.assertAlmostEqual(commands[1].args["TargetY_m"], 0.22)
+
+    def test_parse_program_disallows_recursive_run_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            recursive = Path(tmp) / "recursive.txt"
+            recursive.write_text("run_file recursive.txt\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(IntentError, "recursive run_file include disallowed"):
+                parse_program(recursive)
+
+    def test_simulate_multi_smile_run_file(self):
+        result = simulate_file(Path("GroundStation/GCode/multi_smile.txt"), dt_ms=100)
+
+        draw_segments = [segment for segment in result.segments if segment.pump_on]
+
+        self.assertGreaterEqual(len(draw_segments), 4)
+        self.assertTrue(math.isfinite(result.final_position_m.x))
+        self.assertTrue(math.isfinite(result.final_position_m.y))
 
     def test_simulation_classifies_pump_on_and_off_segments(self):
         commands = [

--- a/Pancake_esp/main/CNCOpCodes.h
+++ b/Pancake_esp/main/CNCOpCodes.h
@@ -16,3 +16,4 @@ constexpr uint8_t CNC_RECTANGLE_OPCODE = 0x1B;
 constexpr uint8_t CNC_GO_TO_ANGLE_OPCODE = 0x1C;
 constexpr uint8_t CNC_HOME_OPCODE = 0x1D;
 constexpr uint8_t CNC_GO_HOME_OPCODE = 0x1E;
+constexpr uint8_t CNC_SET_LOCAL_ORIGIN_OPCODE = 0x1F;

--- a/Pancake_esp/main/CommandHandler.cpp
+++ b/Pancake_esp/main/CommandHandler.cpp
@@ -26,6 +26,7 @@ static inline bool is_cnc_opcode(uint8_t op)
         case CNC_GO_TO_ANGLE_OPCODE:
         case CNC_HOME_OPCODE:
         case CNC_GO_HOME_OPCODE:
+        case CNC_SET_LOCAL_ORIGIN_OPCODE:
             return true;
         default:
             return false;

--- a/Pancake_esp/main/MotorControl.cpp
+++ b/Pancake_esp/main/MotorControl.cpp
@@ -71,23 +71,23 @@ struct LocalOriginConfig
     float OriginY_m;
 };
 
-static void ApplyLocalOriginToCartesianConfig(uint8_t opcode, const uint8_t *payload, Vector2D localOrigin_m)
+static void ApplyLocalOriginToCartesianConfig(uint8_t opcode, uint8_t *payload, Vector2D localOrigin_m)
 {
     if (opcode == CNC_JOG_OPCODE)
     {
-        JogConfig *config = reinterpret_cast<JogConfig *>(const_cast<uint8_t *>(payload));
+        JogConfig *config = reinterpret_cast<JogConfig *>(payload);
         config->TargetX_m += localOrigin_m.x;
         config->TargetY_m += localOrigin_m.y;
     }
     else if (opcode == CNC_ARC_OPCODE)
     {
-        ArcConfig *config = reinterpret_cast<ArcConfig *>(const_cast<uint8_t *>(payload));
+        ArcConfig *config = reinterpret_cast<ArcConfig *>(payload);
         config->CenterX_m += localOrigin_m.x;
         config->CenterY_m += localOrigin_m.y;
     }
     else if (opcode == CNC_SPIRAL_OPCODE)
     {
-        SpiralConfig *config = reinterpret_cast<SpiralConfig *>(const_cast<uint8_t *>(payload));
+        SpiralConfig *config = reinterpret_cast<SpiralConfig *>(payload);
         config->CenterX_m += localOrigin_m.x;
         config->CenterY_m += localOrigin_m.y;
     }
@@ -286,7 +286,7 @@ void MotorControlTask(void *Parameters)
             }
             else
             {
-                const uint8_t *payload = decoded.instructions + 2;
+                uint8_t *payload = decoded.instructions + 2;
                 ESP_LOGI(TAG, "Configuring OpCode: 0x%02X", decoded.opcode);
 
                 if (decoded.opcode == CNC_HOME_OPCODE)

--- a/Pancake_esp/main/MotorControl.cpp
+++ b/Pancake_esp/main/MotorControl.cpp
@@ -24,6 +24,7 @@ motor_tlm_t LocalPumpTlm;
 Vector2D Pos_m{0.0f, 0.0f};
 Vector2D Vel_mps{0.0f, 0.0f};
 Vector2D Target_m{0.0f, 0.0f};
+Vector2D LocalOrigin_m{0.0f, 0.0f};
 
 bool CNCEnabled = false;
 static bool EStopActive = false;
@@ -62,6 +63,34 @@ static bool ApplyGoHomeGuidanceConfig(GeneralGuidance &guidance, const uint8_t *
     GoToAngleConfig config{GO_HOME_S0_ANGLE_DEG, GO_HOME_S1_ANGLE_DEG, DEFAULT_ANGLE_TOLERANCE_DEG};
     static_cast<GoToAngleGuidance &>(guidance).ApplyConfig(config);
     return true;
+}
+
+struct LocalOriginConfig
+{
+    float OriginX_m;
+    float OriginY_m;
+};
+
+static void ApplyLocalOriginToCartesianConfig(uint8_t opcode, const uint8_t *payload, Vector2D localOrigin_m)
+{
+    if (opcode == CNC_JOG_OPCODE)
+    {
+        JogConfig *config = reinterpret_cast<JogConfig *>(const_cast<uint8_t *>(payload));
+        config->TargetX_m += localOrigin_m.x;
+        config->TargetY_m += localOrigin_m.y;
+    }
+    else if (opcode == CNC_ARC_OPCODE)
+    {
+        ArcConfig *config = reinterpret_cast<ArcConfig *>(const_cast<uint8_t *>(payload));
+        config->CenterX_m += localOrigin_m.x;
+        config->CenterY_m += localOrigin_m.y;
+    }
+    else if (opcode == CNC_SPIRAL_OPCODE)
+    {
+        SpiralConfig *config = reinterpret_cast<SpiralConfig *>(const_cast<uint8_t *>(payload));
+        config->CenterX_m += localOrigin_m.x;
+        config->CenterY_m += localOrigin_m.y;
+    }
 }
 
 static void LogGuidanceLoadError(const GuidanceLoadError &error)
@@ -281,8 +310,25 @@ void MotorControlTask(void *Parameters)
                         ESP_LOGI(TAG, "Starting homing operation");
                     }
                 }
+                else if (decoded.opcode == CNC_SET_LOCAL_ORIGIN_OPCODE)
+                {
+                    if (payloadLength != sizeof(LocalOriginConfig))
+                    {
+                        ESP_LOGE(TAG, "Invalid payload length for OpCode 0x%02X: expected %u got %u",
+                                 decoded.opcode, (unsigned)sizeof(LocalOriginConfig), (unsigned)payloadLength);
+                    }
+                    else
+                    {
+                        LocalOriginConfig originConfig{};
+                        memcpy(&originConfig, payload, sizeof(originConfig));
+                        LocalOrigin_m = {originConfig.OriginX_m, originConfig.OriginY_m};
+                        ESP_LOGI(TAG, "Local origin set to %.3f, %.3f m", LocalOrigin_m.x, LocalOrigin_m.y);
+                    }
+                    state.instructionComplete = true;
+                }
                 else
                 {
+                    ApplyLocalOriginToCartesianConfig(decoded.opcode, payload, LocalOrigin_m);
                     GuidanceLoadResult loadResult{};
                     GuidanceLoadError loadError{};
                     bool configApplied = guidanceRegistry.Load(decoded.opcode, payload, payloadLength, loadResult, loadError);


### PR DESCRIPTION
### Motivation
- Enable printing multiple copies of a pancake design from a single run file by defining and using a per-run `local_origin` offset. 
- Provide a simple way to set a local X/Y origin from the ground station and have firmware apply that origin to subsequent cartesian motions. 
- Allow `run_file` to include other run files to compose multi-pattern jobs while preventing infinite recursion.

### Description
- Firmware: added `CNC_SET_LOCAL_ORIGIN_OPCODE` (`0x1F`), a `LocalOrigin_m` variable defaulting to `0.0, 0.0`, a `LocalOriginConfig` payload type, and handling in `MotorControl.cpp` to set the origin and apply it to cartesian guidance payloads (jog, arc, spiral) before loading guidance. 
- Ground station: added `local_origin` command mapping to opcode `0x1F`, request/packet builder for `OriginX_m`/`OriginY_m`, help/completion entries, and `local_origin` support in `_build_cnc_payload` in `GroundStation/CommandTerminal.py`. 
- `run_file` improvements: implemented `_run_file(path, delay_ms, run_file_stack)` and allowed nested `run_file` calls, passing a stack to detect and disallow recursive includes (raises on recursion). 
- Patterns and examples: created origin-centered pattern files `GroundStation/GCode/smily_pattern.txt` and `GroundStation/GCode/work_logo_pattern.txt`, and multi-copy drivers `GroundStation/GCode/multi_smile.txt` and `GroundStation/GCode/multi_work_logo.txt` that set `local_origin` and `run_file` the centered patterns. 
- Tests: added unit tests in `GroundStation/tests/test_command_terminal.py` covering `local_origin` packet encoding, nested `run_file` execution, and recursion rejection.

### Testing
- Ran `python3 -m unittest GroundStation.tests.test_command_terminal` which passed (all tests OK). 
- Ran full unit test script `./scripts/run_unit_tests.sh` and observed all included unit tests complete successfully (several device/algorithm tests printed `... unit test passed`). 
- Verified `GroundStation/CommandTerminal.py` compiles with `python3 -m py_compile` and basic lint/checks (`git diff --check`) showed no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37ec1507b08322a0b1502bf40ccd65)