### PR TITLE
Generalize telemetry rate registry

### DIFF
--- a/Pancake_esp/main/InfluxDBCmdAndTlm.cpp
+++ b/Pancake_esp/main/InfluxDBCmdAndTlm.cpp
@@ -3,6 +3,7 @@
 #include "CommandHandler.h"
 #include "DataModel.h"
 #include "GPIOAssignments.h"
+#include "PanMath.h"
 #include <cstring>
 #include <algorithm>
 
@@ -29,6 +30,83 @@ static void InitializeUART2()
     ESP_ERROR_CHECK(uart_set_pin(UART_NUM, UART_TX_PIN, UART_RX_PIN, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE));
     ESP_ERROR_CHECK(uart_driver_install(UART_NUM, 1024, 1024, 0, NULL, 0));
     ESP_LOGI(TAG, "UART2 initialized on TX=%d, RX=%d at 115200 baud", UART_TX_PIN, UART_RX_PIN);
+}
+
+namespace
+{
+static constexpr int64_t TELEMETRY_PERIOD_1HZ_MS = 1000;
+static constexpr int64_t TELEMETRY_PERIOD_0_25HZ_MS = 4000;
+static constexpr int64_t TELEMETRY_PERIOD_0_05HZ_MS = 20000;
+static constexpr size_t MAX_REGISTERED_TELEMETRY_POINTS = 32;
+
+enum class TelemetryValueType
+{
+    Float,
+    Bool,
+};
+
+typedef struct
+{
+    const char *measurement;
+    const void *value;
+    TelemetryValueType valueType;
+    int64_t period_ms;
+    int64_t lastPublished_ms;
+} registered_telemetry_point_t;
+
+static void RegisterTelemetryPoint(registered_telemetry_point_t *registry,
+                                   size_t registryCapacity,
+                                   size_t &registryCount,
+                                   const char *measurement,
+                                   const float *value,
+                                   int64_t period_ms)
+{
+    if (registryCount >= registryCapacity)
+    {
+        ESP_LOGE(TAG, "Telemetry registry full; dropping %s", measurement);
+        return;
+    }
+
+    registry[registryCount++] = {
+        .measurement = measurement,
+        .value = value,
+        .valueType = TelemetryValueType::Float,
+        .period_ms = period_ms,
+        .lastPublished_ms = 0,
+    };
+}
+
+static void RegisterTelemetryPoint(registered_telemetry_point_t *registry,
+                                   size_t registryCapacity,
+                                   size_t &registryCount,
+                                   const char *measurement,
+                                   const bool *value,
+                                   int64_t period_ms)
+{
+    if (registryCount >= registryCapacity)
+    {
+        ESP_LOGE(TAG, "Telemetry registry full; dropping %s", measurement);
+        return;
+    }
+
+    registry[registryCount++] = {
+        .measurement = measurement,
+        .value = value,
+        .valueType = TelemetryValueType::Bool,
+        .period_ms = period_ms,
+        .lastPublished_ms = 0,
+    };
+}
+
+static float ReadTelemetryValue(const registered_telemetry_point_t &point)
+{
+    if (point.valueType == TelemetryValueType::Bool)
+    {
+        return *(static_cast<const bool *>(point.value)) ? 1.0f : 0.0f;
+    }
+
+    return *(static_cast<const float *>(point.value));
+}
 }
 
 SemaphoreHandle_t TlmBufferMutex = nullptr;
@@ -478,70 +556,123 @@ void AggregateTlmTask(void *Parameters)
     struct timeval tv;
     bool sendBufferOverflowWarning = true;
 
+    Vector2D boundaryCorners_m[4];
+    if (GetReachableRectangleCorners(boundaryCorners_m))
+    {
+        TelemetryData.cartesianBoundaryCorner0_X_m = boundaryCorners_m[0].x;
+        TelemetryData.cartesianBoundaryCorner0_Y_m = boundaryCorners_m[0].y;
+        TelemetryData.cartesianBoundaryCorner1_X_m = boundaryCorners_m[1].x;
+        TelemetryData.cartesianBoundaryCorner1_Y_m = boundaryCorners_m[1].y;
+        TelemetryData.cartesianBoundaryCorner2_X_m = boundaryCorners_m[2].x;
+        TelemetryData.cartesianBoundaryCorner2_Y_m = boundaryCorners_m[2].y;
+        TelemetryData.cartesianBoundaryCorner3_X_m = boundaryCorners_m[3].x;
+        TelemetryData.cartesianBoundaryCorner3_Y_m = boundaryCorners_m[3].y;
+    }
+    else
+    {
+        ESP_LOGE(TAG, "Reachable Cartesian boundary corners unavailable for telemetry");
+    }
+
+    registered_telemetry_point_t telemetryRegistry[MAX_REGISTERED_TELEMETRY_POINTS];
+    size_t telemetryRegistryCount = 0;
+
+    // Register telemetry point cadences in one place rather than hard-coding named buckets.
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "tipPos_X_m", &TelemetryData.tipPos_X_m, TELEMETRY_PERIOD_1HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "tipPos_Y_m", &TelemetryData.tipPos_Y_m, TELEMETRY_PERIOD_1HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "targetPos_X_m", &TelemetryData.targetPos_X_m, TELEMETRY_PERIOD_1HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "targetPos_Y_m", &TelemetryData.targetPos_Y_m, TELEMETRY_PERIOD_1HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "S0_Speed_degps", &TelemetryData.S0MotorTlm.Speed_degps, TELEMETRY_PERIOD_1HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "S0_TargetSpeed_degps", &TelemetryData.S0MotorTlm.TargetSpeed_degps, TELEMETRY_PERIOD_1HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "S1_Speed_degps", &TelemetryData.S1MotorTlm.Speed_degps, TELEMETRY_PERIOD_1HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "S1_TargetSpeed_degps", &TelemetryData.S1MotorTlm.TargetSpeed_degps, TELEMETRY_PERIOD_1HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "Pump_Speed_degps", &TelemetryData.PumpMotorTlm.Speed_degps, TELEMETRY_PERIOD_1HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "Pump_TargetSpeed_degps", &TelemetryData.PumpMotorTlm.TargetSpeed_degps, TELEMETRY_PERIOD_1HZ_MS);
+
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "targetPos_S0_deg", &TelemetryData.targetPos_S0_deg, TELEMETRY_PERIOD_0_25HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "targetPos_S1_deg", &TelemetryData.targetPos_S1_deg, TELEMETRY_PERIOD_0_25HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "plannedTarget_S0_deg", &TelemetryData.plannedTarget_S0_deg, TELEMETRY_PERIOD_0_25HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "plannedTarget_S1_deg", &TelemetryData.plannedTarget_S1_deg, TELEMETRY_PERIOD_0_25HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "plannedDelta_S0_deg", &TelemetryData.plannedDelta_S0_deg, TELEMETRY_PERIOD_0_25HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "plannedDelta_S1_deg", &TelemetryData.plannedDelta_S1_deg, TELEMETRY_PERIOD_0_25HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "S0_Pos_deg", &TelemetryData.S0MotorTlm.Position_deg, TELEMETRY_PERIOD_0_25HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "S1_Pos_deg", &TelemetryData.S1MotorTlm.Position_deg, TELEMETRY_PERIOD_0_25HZ_MS);
+
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "espTemp_C", &TelemetryData.espTemp_C, TELEMETRY_PERIOD_0_05HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "limitBlocked_S0", &TelemetryData.limitBlocked_S0, TELEMETRY_PERIOD_0_05HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "limitBlocked_S1", &TelemetryData.limitBlocked_S1, TELEMETRY_PERIOD_0_05HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "S0_LimitSwitch", &TelemetryData.S0LimitSwitch, TELEMETRY_PERIOD_0_05HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "S1_LimitSwitch", &TelemetryData.S1LimitSwitch, TELEMETRY_PERIOD_0_05HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "cartesianBoundaryCorner0_X_m", &TelemetryData.cartesianBoundaryCorner0_X_m, TELEMETRY_PERIOD_0_05HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "cartesianBoundaryCorner0_Y_m", &TelemetryData.cartesianBoundaryCorner0_Y_m, TELEMETRY_PERIOD_0_05HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "cartesianBoundaryCorner1_X_m", &TelemetryData.cartesianBoundaryCorner1_X_m, TELEMETRY_PERIOD_0_05HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "cartesianBoundaryCorner1_Y_m", &TelemetryData.cartesianBoundaryCorner1_Y_m, TELEMETRY_PERIOD_0_05HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "cartesianBoundaryCorner2_X_m", &TelemetryData.cartesianBoundaryCorner2_X_m, TELEMETRY_PERIOD_0_05HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "cartesianBoundaryCorner2_Y_m", &TelemetryData.cartesianBoundaryCorner2_Y_m, TELEMETRY_PERIOD_0_05HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "cartesianBoundaryCorner3_X_m", &TelemetryData.cartesianBoundaryCorner3_X_m, TELEMETRY_PERIOD_0_05HZ_MS);
+    RegisterTelemetryPoint(telemetryRegistry, MAX_REGISTERED_TELEMETRY_POINTS, telemetryRegistryCount,
+                           "cartesianBoundaryCorner3_Y_m", &TelemetryData.cartesianBoundaryCorner3_Y_m, TELEMETRY_PERIOD_0_05HZ_MS);
+
     for (;;)
     {
         gettimeofday(&tv, NULL);
         timeStamp = (int64_t)tv.tv_sec * 1000.0 + (int64_t)tv.tv_usec / 1000L;
 
-        // Acquire the mutex before updating shared data
-        if (true)
+        // Drain a limited number of captured log lines to avoid WDT starvation
+        const int LOG_DRAIN_MAX = 32;
+        int drained = 0;
+        char msg[LOG_MSG_MAX_LEN];
+        while (drained < LOG_DRAIN_MAX && log_ring_pop(&TlmLogRing, msg, sizeof(msg)))
         {
-            // Drain a limited number of captured log lines to avoid WDT starvation
-            const int LOG_DRAIN_MAX = 32;
-            int drained = 0;
-            char msg[LOG_MSG_MAX_LEN];
-            while (drained < LOG_DRAIN_MAX && log_ring_pop(&TlmLogRing, msg, sizeof(msg)))
-            {
-                AddLogToBuffer(msg);
-                ++drained;
-            }
-
-            if (sendBufferOverflowWarning && WorkingTlmBufferIdx > WARN_BUFFER_SIZE)
-            {
-                ESP_LOGW(TAG, "Buffer overflow warning: %d bytes used", WorkingTlmBufferIdx);
-                sendBufferOverflowWarning = false;
-            }
-
-            // Add telemetry data to buffer
-            AddDataToBuffer("espTemp_C", "data", TelemetryData.espTemp_C, timeStamp);
-
-            AddDataToBuffer("tipPos_X_m", "data", TelemetryData.tipPos_X_m, timeStamp);
-            AddDataToBuffer("tipPos_Y_m", "data", TelemetryData.tipPos_Y_m, timeStamp);
-
-            AddDataToBuffer("targetPos_X_m", "data", TelemetryData.targetPos_X_m, timeStamp);
-            AddDataToBuffer("targetPos_Y_m", "data", TelemetryData.targetPos_Y_m, timeStamp);
-
-            AddDataToBuffer("targetPos_S0_deg", "data", TelemetryData.targetPos_S0_deg, timeStamp);
-            AddDataToBuffer("targetPos_S1_deg", "data", TelemetryData.targetPos_S1_deg, timeStamp);
-            AddDataToBuffer("plannedTarget_S0_deg", "data", TelemetryData.plannedTarget_S0_deg, timeStamp);
-            AddDataToBuffer("plannedTarget_S1_deg", "data", TelemetryData.plannedTarget_S1_deg, timeStamp);
-            AddDataToBuffer("plannedDelta_S0_deg", "data", TelemetryData.plannedDelta_S0_deg, timeStamp);
-            AddDataToBuffer("plannedDelta_S1_deg", "data", TelemetryData.plannedDelta_S1_deg, timeStamp);
-            AddDataToBuffer("limitBlocked_S0", "data", TelemetryData.limitBlocked_S0, timeStamp);
-            AddDataToBuffer("limitBlocked_S1", "data", TelemetryData.limitBlocked_S1, timeStamp);
-
-            AddDataToBuffer("S0_LimitSwitch", "data", TelemetryData.S0LimitSwitch, timeStamp);
-            AddDataToBuffer("S0_Pos_deg", "data", TelemetryData.S0MotorTlm.Position_deg, timeStamp);
-            AddDataToBuffer("S0_Speed_degps", "data", TelemetryData.S0MotorTlm.Speed_degps,
-                            timeStamp);
-            AddDataToBuffer("S0_TargetSpeed_degps", "data", TelemetryData.S0MotorTlm.TargetSpeed_degps,
-                            timeStamp);
-
-            AddDataToBuffer("S1_LimitSwitch", "data", TelemetryData.S1LimitSwitch, timeStamp);
-            AddDataToBuffer("S1_Pos_deg", "data", TelemetryData.S1MotorTlm.Position_deg, timeStamp);
-            AddDataToBuffer("S1_Speed_degps", "data", TelemetryData.S1MotorTlm.Speed_degps,
-                            timeStamp);
-            AddDataToBuffer("S1_TargetSpeed_degps", "data", TelemetryData.S1MotorTlm.TargetSpeed_degps,
-                            timeStamp);
-
-            // AddDataToBuffer("Pump_Pos_deg", "data", TelemetryData.PumpMotorTlm.Position_deg,
-            // timeStamp);
-            AddDataToBuffer("Pump_Speed_degps", "data", TelemetryData.PumpMotorTlm.Speed_degps,
-                            timeStamp);
-            AddDataToBuffer("Pump_TargetSpeed_degps", "data",
-                            TelemetryData.PumpMotorTlm.TargetSpeed_degps, timeStamp);
+            AddLogToBuffer(msg);
+            ++drained;
         }
-        
+
+        if (sendBufferOverflowWarning && WorkingTlmBufferIdx > WARN_BUFFER_SIZE)
+        {
+            ESP_LOGW(TAG, "Buffer overflow warning: %d bytes used", WorkingTlmBufferIdx);
+            sendBufferOverflowWarning = false;
+        }
+
+        for (size_t i = 0; i < telemetryRegistryCount; ++i)
+        {
+            registered_telemetry_point_t &point = telemetryRegistry[i];
+            if (point.lastPublished_ms == 0 || timeStamp - point.lastPublished_ms >= point.period_ms)
+            {
+                AddDataToBuffer(point.measurement, "data", ReadTelemetryValue(point), timeStamp);
+                point.lastPublished_ms = timeStamp;
+            }
+        }
+
         vTaskDelay(bufferAddPeriod_Ticks);
 
     }

--- a/Pancake_esp/main/Telemetry.h
+++ b/Pancake_esp/main/Telemetry.h
@@ -33,6 +33,14 @@ typedef struct {
     float plannedDelta_S1_deg;
     bool limitBlocked_S0;
     bool limitBlocked_S1;
+    float cartesianBoundaryCorner0_X_m;
+    float cartesianBoundaryCorner0_Y_m;
+    float cartesianBoundaryCorner1_X_m;
+    float cartesianBoundaryCorner1_Y_m;
+    float cartesianBoundaryCorner2_X_m;
+    float cartesianBoundaryCorner2_Y_m;
+    float cartesianBoundaryCorner3_X_m;
+    float cartesianBoundaryCorner3_Y_m;
 } telemetry_data_t;
 
 extern telemetry_data_t TelemetryData;

--- a/Pancake_esp/main/defines.h
+++ b/Pancake_esp/main/defines.h
@@ -7,7 +7,7 @@
 // Task timing
 #define MOTOR_CONTROL_PERIOD_MS 10
 #define SAFETY_PERIOD_MS 10
-#define BUFFER_ADD_PERIOD_MS 1200
+#define BUFFER_ADD_PERIOD_MS 1000
 
 
 #define CUSTOM_ERROR_CHECK(err)                                                                    \

--- a/telemetrybudget.md
+++ b/telemetrybudget.md
@@ -1,0 +1,62 @@
+# Telemetry Budget
+
+This document summarizes the registered telemetry points, their update rates, and the expected InfluxDB line-protocol payload size per transmit period.
+
+## Scheduling model
+
+Telemetry aggregation runs once every `BUFFER_ADD_PERIOD_MS` (`1000 ms`, or `1 Hz`). The transmit task runs every `TRANSMITPERIOD_MS` (`900 ms`) and sends whatever has accumulated in the working telemetry buffer since the previous transmit attempt.
+
+Each telemetry point is registered with its own period. There are no separate runtime buckets; the aggregate task walks the registry and publishes any point whose configured period has elapsed.
+
+Log lines are also added to the same telemetry buffer when present, but they are event-driven and are **not** included in the fixed-rate budget below.
+
+## Fixed-rate telemetry points
+
+| Rate | Period | Points | Measurements |
+| --- | ---: | ---: | --- |
+| `1 Hz` | `1000 ms` | 10 | `tipPos_X_m`, `tipPos_Y_m`, `targetPos_X_m`, `targetPos_Y_m`, `S0_Speed_degps`, `S0_TargetSpeed_degps`, `S1_Speed_degps`, `S1_TargetSpeed_degps`, `Pump_Speed_degps`, `Pump_TargetSpeed_degps` |
+| `0.25 Hz` | `4000 ms` | 8 | `targetPos_S0_deg`, `targetPos_S1_deg`, `plannedTarget_S0_deg`, `plannedTarget_S1_deg`, `plannedDelta_S0_deg`, `plannedDelta_S1_deg`, `S0_Pos_deg`, `S1_Pos_deg` |
+| `0.05 Hz` | `20000 ms` | 13 | `espTemp_C`, `limitBlocked_S0`, `limitBlocked_S1`, `S0_LimitSwitch`, `S1_LimitSwitch`, `cartesianBoundaryCorner0_X_m`, `cartesianBoundaryCorner0_Y_m`, `cartesianBoundaryCorner1_X_m`, `cartesianBoundaryCorner1_Y_m`, `cartesianBoundaryCorner2_X_m`, `cartesianBoundaryCorner2_Y_m`, `cartesianBoundaryCorner3_X_m`, `cartesianBoundaryCorner3_Y_m` |
+
+## Size assumptions
+
+The fixed-rate byte estimates assume the current line protocol format:
+
+```text
+<measurement>,location=us-midwest data=<value> <timestamp>\n
+```
+
+Assumptions used for the estimate:
+
+- `<value>` is formatted by `%.5f`; the estimate uses `0.00000` (`7` bytes). Negative values or values with more integer digits add bytes.
+- `<timestamp>` is a 13-digit millisecond timestamp.
+- One newline is included per telemetry point.
+- HTTP headers, TLS overhead, TCP/IP framing, and event-driven log telemetry are excluded.
+
+## Payload budget by cadence
+
+| Cadence contribution | Points | Bytes per cadence event | Average bytes per second |
+| --- | ---: | ---: | ---: |
+| `1 Hz` points | 10 | ~632 B every 1 s | ~632.00 B/s |
+| `0.25 Hz` points | 8 | ~514 B every 4 s | ~128.50 B/s |
+| `0.05 Hz` points | 13 | ~915 B every 20 s | ~45.75 B/s |
+| **Total fixed-rate average** | 31 | N/A | **~806.25 B/s** |
+
+## Expected bytes per transmit period
+
+Because the transmit task runs every `900 ms` and aggregation runs every `1000 ms`, not every transmit tick contains a new aggregate sample. Over a long-running average, fixed-rate telemetry produces:
+
+```text
+806.25 B/s * 0.9 s/transmit period = ~725.6 B/transmit period
+```
+
+Representative fixed-rate transmit payloads are:
+
+| Transmit payload case | Approximate payload bytes | Notes |
+| --- | ---: | --- |
+| Empty fixed-rate transmit | 0 B | Possible when the 900 ms transmit task wakes before a new 1000 ms aggregate cycle has added data. |
+| 1 Hz-only aggregate | ~632 B | Most aggregate cycles. |
+| 1 Hz + 0.25 Hz aggregate | ~1,146 B | Every 4 seconds. |
+| 1 Hz + 0.25 Hz + 0.05 Hz aggregate | ~2,061 B | Every 20 seconds, when all registered periods align. |
+
+The fixed telemetry buffer size is `6000 B` with a warning threshold of `5500 B`, so the largest fixed-rate aligned payload is currently about `2.1 kB`, leaving roughly `3.9 kB` of buffer headroom for queued log lines and larger-than-assumed numeric values.


### PR DESCRIPTION
### Motivation
- Avoid hard-coded fast/medium/slow telemetry buckets and simplify the aggregation logic.
- Make telemetry update cadence a per-point configuration so new points can be added with an explicit period.
- Preserve the Cartesian reachable-boundary telemetry so boundary corners remain available for visualization.

### Description
- Added a small telemetry registry and helpers in `Pancake_esp/main/InfluxDBCmdAndTlm.cpp` (types: `registered_telemetry_point_t`, `TelemetryValueType`, `RegisterTelemetryPoint` overloads, and `ReadTelemetryValue`) to store measurement name, source pointer, value type, period, and last-published timestamp.
- Replaced the previous bucket-specific scheduling with a registry-driven loop that iterates registered points and emits each point when its configured `period_ms` has elapsed, and registered existing telemetry points with 1Hz / 0.25Hz / 0.05Hz periods.
- Kept the `GetReachableRectangleCorners` computation and added the four `cartesianBoundaryCornerN_X_m` / `cartesianBoundaryCornerN_Y_m` fields to `Pancake_esp/main/Telemetry.h` so the corners are published at the configured cadence.
- Tuned the aggregation base loop by changing `BUFFER_ADD_PERIOD_MS` to `1000` in `Pancake_esp/main/defines.h` to run the registry at a 1Hz base cadence.

### Testing
- Ran `./scripts/run_unit_tests.sh` and all unit tests completed successfully.
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37ecc7c7f88322a633a4e868558fa5)